### PR TITLE
Add whitespace between examples for better help2man result

### DIFF
--- a/openaptxdec.c
+++ b/openaptxdec.c
@@ -70,8 +70,11 @@ int main(int argc, char *argv[])
             fprintf(stderr, "        --hd         Decode from aptX HD\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "Examples:\n");
+            fprintf(stderr, "\n");
             fprintf(stderr, "        %s < sample.aptx > sample.s24le\n", argv[0]);
+            fprintf(stderr, "\n");
             fprintf(stderr, "        %s --hd < sample.aptxhd > sample.s24le\n", argv[0]);
+            fprintf(stderr, "\n");
             fprintf(stderr, "        %s < sample.aptx | play -t raw -r 44.1k -L -e s -b 24 -c 2 -\n", argv[0]);
             return 1;
         } else if (strcmp(argv[i], "--hd") == 0) {

--- a/openaptxenc.c
+++ b/openaptxenc.c
@@ -62,8 +62,11 @@ int main(int argc, char *argv[])
             fprintf(stderr, "        --hd         Encode to aptX HD\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "Examples:\n");
+            fprintf(stderr, "\n");
             fprintf(stderr, "        %s < sample.s24le > sample.aptx\n", argv[0]);
+            fprintf(stderr, "\n");
             fprintf(stderr, "        %s --hd < sample.s24le > sample.aptxhd\n", argv[0]);
+            fprintf(stderr, "\n");
             fprintf(stderr, "        sox sample.wav -t raw -r 44.1k -L -e s -b 24 -c 2 - | %s > sample.aptx\n", argv[0]);
             return 1;
         } else if (strcmp(argv[i], "--hd") == 0) {


### PR DESCRIPTION
As discussed, the examples end up being on one line only. Adding this little whitespace provides for a better resulting manpage