### PR TITLE
Add support for Meson build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LNS = ln -sf
 MKDIR = mkdir -p
 PRINTF = printf
 
-CFLAGS = -W -Wall -O3
+CFLAGS = -W -Wall -O3 -DAPTX_API=extern
 LDFLAGS = -s
 ARFLAGS = -rcs
 

--- a/get-version.py
+++ b/get-version.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+#
+#  get-version.py (for meson build)
+#
+# Extracts versions for build from .h header
+import subprocess
+import os
+import sys
+import shutil
+
+if __name__ == '__main__':
+    srcroot = os.path.normpath(os.path.join(os.path.dirname(__file__)))
+
+    openaptx_lt_major = None
+    openaptx_lt_minor = None
+    openaptx_lt_patch = None
+
+    with open(os.path.join(srcroot, 'openaptx.h'), 'r') as f:
+        for line in f:
+            if line.strip().startswith('#define OPENAPTX_MAJOR '):
+                openaptx_lt_major = line[23:].strip()
+            elif line.strip().startswith('#define OPENAPTX_MINOR '):
+                openaptx_lt_minor = line[23:].strip()
+            elif line.strip().startswith('#define OPENAPTX_PATCH '):
+                openaptx_lt_patch = line[23:].strip()
+
+    if openaptx_lt_major and openaptx_lt_minor and openaptx_lt_patch:
+        print('{}.{}.{}'.format(openaptx_lt_major, openaptx_lt_minor, openaptx_lt_patch))
+        sys.exit(0)
+    else:
+        print('ERROR: Could not extract openaptx version from openaptx.h file in', srcroot, file=sys.stderr)
+        sys.exit(-1)

--- a/meson.build
+++ b/meson.build
@@ -11,8 +11,33 @@ soversion = version_major
 libversion = '@0@.@1@.0'.format(version_major, version_minor, version_micro)
 osxversion = version_minor + 1
 
+cc = meson.get_compiler('c')
+
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
+cdata = configuration_data()
+
+# Symbol visibility
+if cc.get_id() == 'msvc'
+  export_define = '__declspec(dllexport) extern'
+elif cc.has_argument('-fvisibility=hidden')
+  add_project_arguments('-fvisibility=hidden', language: 'c')
+  export_define = 'extern __attribute__ ((visibility ("default")))'
+else
+  export_define = 'extern'
+endif
+
+# Passing this through the command line would be too messy
+cdata.set('APTX_API_EXPORT', export_define)
+
+static_cflags = []
+if get_option('default_library') == 'static'
+  static_cflags += ['-DAPTX_STATIC_COMPILATION']
+endif
+
 # library
 libopenaptx = library('openaptx', 'openaptx.c',
+   c_args: ['-DBUILDING_APTX'],
    version: libversion,
    soversion: soversion,
    darwin_versions: osxversion)
@@ -20,15 +45,20 @@ libopenaptx = library('openaptx', 'openaptx.c',
 openaptx_incdir = include_directories('.')
 
 openaptx_dep = declare_dependency(link_with: libopenaptx,
-  include_directories: openaptx_incdir)
+  include_directories: openaptx_incdir,
+  compile_args: static_cflags)
 
 meson.override_dependency('openaptx', openaptx_dep)
+
+# config.h
+configure_file(output: 'config.h', configuration: cdata)
 
 # pkg-config file
 pkg = import('pkgconfig')
 pkg.generate(libopenaptx,
   name: 'libopenaptx',
-  description: 'Open Source aptX codec library')
+  description: 'Open Source aptX codec library',
+  extra_cflags: static_cflags)
 
 # tools
 if not get_option('tools').disabled()

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,37 @@
+project('openaptx', 'c',
+  version: run_command('get-version.py', check: true).stdout().strip(),
+  default_options: ['buildtype=debugoptimized'])
+
+version_arr = meson.project_version().split('.')
+version_major = version_arr[0].to_int()
+version_minor = version_arr[1].to_int()
+version_micro = version_arr[2].to_int()
+
+soversion = version_major
+libversion = '@0@.@1@.0'.format(version_major, version_minor, version_micro)
+osxversion = version_minor + 1
+
+# library
+libopenaptx = library('openaptx', 'openaptx.c',
+   version: libversion,
+   soversion: soversion,
+   darwin_versions: osxversion)
+
+openaptx_incdir = include_directories('.')
+
+openaptx_dep = declare_dependency(link_with: libopenaptx,
+  include_directories: openaptx_incdir)
+
+meson.override_dependency('openaptx', openaptx_dep)
+
+# pkg-config file
+pkg = import('pkgconfig')
+pkg.generate(libopenaptx,
+  name: 'libopenaptx',
+  description: 'Open Source aptX codec library')
+
+# tools
+if not get_option('tools').disabled()
+  executable('openaptxdec', 'openaptxdec.c', dependencies: openaptx_dep)
+  executable('openaptxenc', 'openaptxenc.c', dependencies: openaptx_dep)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('tools', type : 'feature', value : 'auto',
+  description: 'Build openaptx command line tools')

--- a/openaptx.c
+++ b/openaptx.c
@@ -17,6 +17,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/openaptx.h
+++ b/openaptx.h
@@ -26,9 +26,28 @@
 
 #include <stddef.h>
 
-extern const int aptx_major;
-extern const int aptx_minor;
-extern const int aptx_patch;
+/* Symbol visibility
+ *
+ * Note: To link to openaptx statically on Windows, you must define
+ * APTX_STATIC_COMPILATION or the prototypes will cause the compiler to
+ * search for the symbol inside a DLL. */
+#if defined(_MSC_VER) && !defined(APTX_STATIC_COMPILATION)
+# define APTX_API_IMPORT __declspec(dllimport) extern
+#else
+# define APTX_API_IMPORT extern
+#endif
+
+#ifndef APTX_API
+# ifdef BUILDING_APTX
+#  define APTX_API APTX_API_EXPORT     /* set via compiler flags or config.h */
+# else
+#  define APTX_API APTX_API_IMPORT
+# endif
+#endif
+
+APTX_API const int aptx_major;
+APTX_API const int aptx_minor;
+APTX_API const int aptx_patch;
 
 struct aptx_context;
 
@@ -37,17 +56,20 @@ struct aptx_context;
  * hd = 0 process aptX codec
  * hd = 1 process aptX HD codec
  */
+APTX_API
 struct aptx_context *aptx_init(int hd);
 
 /*
  * Reset internal state, predictor and parity sync of aptX context.
  * It is needed when going to encode or decode a new stream.
  */
+APTX_API
 void aptx_reset(struct aptx_context *ctx);
 
 /*
  * Free aptX context initialized by aptx_init().
  */
+APTX_API
 void aptx_finish(struct aptx_context *ctx);
 
 /*
@@ -60,6 +82,7 @@ void aptx_finish(struct aptx_context *ctx);
  * encoded sequence of either four bytes (LLRR) of aptX or six bytes (LLLRRR)
  * of aptX HD.
  */
+APTX_API
 size_t aptx_encode(struct aptx_context *ctx,
                    const unsigned char *input,
                    size_t input_size,
@@ -76,6 +99,7 @@ size_t aptx_encode(struct aptx_context *ctx,
  * When output buffer is large enough, then function returns non-zero value.
  * In both cases into written pointer is stored length of encoded samples.
  */
+APTX_API
 int aptx_encode_finish(struct aptx_context *ctx,
                        unsigned char *output,
                        size_t output_size,
@@ -98,6 +122,7 @@ int aptx_encode_finish(struct aptx_context *ctx,
  * samples are rounded to the multiple by four and latency is 90 samples so
  * last 2 samples are just padding.
  */
+APTX_API
 size_t aptx_decode(struct aptx_context *ctx,
                    const unsigned char *input,
                    size_t input_size,
@@ -122,6 +147,7 @@ size_t aptx_decode(struct aptx_context *ctx,
  * already processed. Functions aptx_decode() and aptx_decode_sync() should not
  * be mixed together.
  */
+APTX_API
 size_t aptx_decode_sync(struct aptx_context *ctx,
                         const unsigned char *input,
                         size_t input_size,
@@ -138,6 +164,7 @@ size_t aptx_decode_sync(struct aptx_context *ctx,
  * by next aptx_decode_sync() call, therefore in time of calling this function
  * it is number of dropped input bytes.
  */
+APTX_API
 size_t aptx_decode_sync_finish(struct aptx_context *ctx);
 
 #endif


### PR DESCRIPTION
Please find attached two patches that add support for building libopenaptx with the Meson build system.

The Meson build system has been adopted by projects such as GNOME, GTK, GStreamer, PulseAudio (and maybe VLC in future).

It would be fantastic to have support for building libopenaptx with Meson in upstream libopenaptx as it would facilitate builds of GStreamer/PulseAudio etc. via Meson's subproject support.

Meson also supports builds on Windows with MSVC for those who care about this (Windows developers mostly, since it means they can use native Windows tools for debugging).

I understand that from a maintainer's point of view these kind of unsolicited "add support for a different build system" patches are not always welcome, not least because they might add additional maintenance burden, so apologies in advance for that, but I'm sure the wider GStreamer community (along with myself) would be happy to maintain this going forward in case there are any issues with it.

This would be particularly useful in light of the [openaptx plugin](https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1871) that has been proposed for inclusion in GStreamer.

To try the meson build:
```
$ meson --prefix=/tmp/prefix builddir
$ ninja -C builddir
$ ninja -C builddir install
```
